### PR TITLE
remove the .obsidian dir from  repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ _site/
 _includes/notes_graph.json
 
 # Obsidian config
-.obsidian/*
+#.obsidian/*


### PR DESCRIPTION
Hi,

The .gitignore file ignores the .obsidian directory, but the contents have not been deleted. Do certain files need to be kept in the repository for publishing, or is it just an oversight? 
This can help me and others participate in the documentation.

Do not merge this PR, but rather make a backup and delete the folder yourself to not lose your configuration. 
This commit is just a pretext to create a PR, as 'issues' are not enabled in this project.

Regards