### PR TITLE
Ignore the .vscode config dir from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ _includes/notes_graph.json
 
 # Obsidian config
 .obsidian/*
+
+# VScode config
+#.vscode/


### PR DESCRIPTION
Hi,
The `.vscode` directory needs to be ignored to avoid conflict with each personal config.
Do not merge this PR, but rather ignore the folder yourself to not lose your configuration.
Regards